### PR TITLE
Switch to Nodes implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,42 +1,47 @@
-var assert = console.assert ? console.assert : (function(a, b) {
-	return a || (function() {
-		throw new Error(b);
-	})();
-});
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-var FreeList = (function() {
-	var __slice = [].slice;
+// This is a free list to avoid creating so many of the same object.
+exports.FreeList = function(name, max, constructor) {
+  this.name = name;
+  this.constructor = constructor;
+  this.max = max;
+  this.list = [];
+};
 
-	function FreeList(name, max, constructor) {
-		this.name = name;
-		this.max = max;
-		this.constructor = constructor != null ? constructor : function() {};
-		this.list = [];
-	}
 
-	FreeList.prototype.alloc = function() {
-		var args = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
+exports.FreeList.prototype.alloc = function() {
+  //debug("alloc " + this.name + " " + this.list.length);
+  return this.list.length ? this.list.shift() :
+                            this.constructor.apply(this, arguments);
+};
 
-		if (this.list.length) {
-			return this.list.shift();
-		} else {
-			return this.constructor.apply(this, args);
-		}
-	};
 
-	FreeList.prototype.free = function(obj) {
-		if (this.list.length < this.max) {
-			this.list.push(obj);
-			return true;
-		} else {
-			return false;
-		}
-	};
+exports.FreeList.prototype.free = function(obj) {
+  //debug("free " + this.name + " " + this.list.length);
+  if (this.list.length < this.max) {
+    this.list.push(obj);
+    return true;
+  }
+  return false;
+};
 
-	return FreeList;
-})();
-
-// remain backward compatible
-FreeList.FreeList = FreeList;
-
-module.exports = FreeList
+module.exports = exports.FreeList.FreeList = exports.FreeList;

--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
   "name": "freelist",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Outsource of Node's internal FreeList module (originally by Ryan Dahl)",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "keywords": [
     "free",
     "list",
@@ -13,5 +10,5 @@
   ],
   "repository": "https://github.com/kenansulayman/freelist.git",
   "author": "Kenan Sulayman",
-  "license": "ISC"
+  "license": "MIT"
 }


### PR DESCRIPTION
There is no reason to have a different implementation/code in this module than Node. Since that's what it says to be, an "Outsource of Node's internal FreeList module".
- package.json: changed to MIT license, that's what Node has.
- assert function was unused
- unnecessary arguments to Array conversion: http://stackoverflow.com/a/20375156
- There was a check for undefined constructor. But seriously, who wants a free list of plain Objects? If you really think this is important, you can add it again or increase the major version (=breaking change).
- Added last line in new version to keep support for shorthand without `.FreeList`

I already updated the version, you simply have to `npm publish` yet.
